### PR TITLE
CI: add publishing workflow

### DIFF
--- a/.github/workflows/PublishExtension.yml
+++ b/.github/workflows/PublishExtension.yml
@@ -1,0 +1,22 @@
+on:
+  push:
+    branches:
+      - master
+
+name: Build and Publish Extension
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - run: yarn install
+      - run: yarn vscode:prepublish
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com
+          yarn: true

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "todoist",
   "displayName": "todoist",
   "description": "Use Todoist for managing and syncing todos",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "publisher": "waymondo",
   "browser": "./out/browser.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "todoist",
   "displayName": "todoist",
   "description": "Use Todoist for managing and syncing todos",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publisher": "waymondo",
   "browser": "./out/browser.js",
   "repository": {


### PR DESCRIPTION
This PR implements the [publish-vscode-extenision github workflow](https://github.com/HaaLeo/publish-vscode-extension)
closes #18 

The `VS_MARKETPLACE_TOKEN` secret must be added to this repository github secrets

